### PR TITLE
Real Time Clock support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,14 @@ add_library(agbabi STATIC
     source/memmove.s
     source/memset.s
     source/rmemcpy.s
+    source/rtc.s
     source/sine.s
     source/uidiv.s
     source/uldiv.s
     source/uluidiv.s
 
     source/makecontext.c
+    source/rtc.c
 )
 
 target_include_directories(agbabi SYSTEM PUBLIC include/ include/sys/)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Retrieve the raw chip time and date.
 
 ```c
 int __agbabi_rtc_time();
-long long int __agbabi_rtc_ldatetime();
+long long __agbabi_rtc_ldatetime();
 int __attribute__((__vector_size__(8))) __agbabi_rtc_datetime();
 ```
 
@@ -284,6 +284,16 @@ Writes 8 bits to RTC chip.
 void __agbabi_rtc_write8(int n);
 ```
 
+Set the raw chip time and date.
+
+```c
+void __agbabi_rtc_settime(int time);
+void __agbabi_rtc_setldatetime(long long datetime);
+void __agbabi_rtc_setdatetime(int __attribute__((__vector_size__(8))) datetime);
+```
+
+These take big-endian BCD encoded values.
+
 ## POSIX library
 
 ### getcontext
@@ -310,13 +320,23 @@ Alias of `__aeabi_swapcontext`.
 int swapcontext(ucontext_t *restrict oucp, const ucontext_t *restrict ucp);
 ```
 
-### gettimeofday
-Writes the current time of day to `tv`.
+### _gettimeofday
+Writes the current date to `tv`.
 
 `tz` is unused.
 
 Returns 0 on success.
 ```c
-int _gettimeofday(struct timeval* restrict tv, void* restrict tz);
+int _gettimeofday(struct timeval* restrict tv, struct timezone* restrict tz);
 ```
 This is used internally by the C time APIs.
+
+### settimeofday
+Sets the current date to value pointed to by `tv`.
+
+`tz` is unused.
+
+Returns 0 on success.
+```c
+int settimeofday(const struct timeval* restrict tv, const struct timezone* restrict tz);
+```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,58 @@ void(*__agbabi_irq_uproc)(short irqFlags);
 ```
 The argument `flags` of the `__agbabi_irq_uproc` procedure will contain a mask of the raised IRQs.
 
+### Real Time Clock
+
+Requires RTC chip on cartridge.
+
+#### Initialise RTC
+
+Initializes the RTC clock, returning a non-zero error code if initialization fails.
+
+```c
+int __agbabi_rtc_init();
+```
+
+`__agbabi_rtc_init` returns 0 on success.
+
+**The GPIO port will be left ENABLED on success.**
+
+#### Querying time
+
+Retrieve the raw chip time and date.
+
+```c
+int __agbabi_rtc_time();
+long long int __agbabi_rtc_ldatetime();
+int __attribute__((__vector_size__(8))) __agbabi_rtc_datetime();
+```
+
+These return big-endian BCD encoded values.
+
+`ldatetime` and `datetime` stores date in the upper 32-bits, time in the lower 32-bits.
+
+#### RTC status
+
+Returns the RTC chip status.
+
+```c
+int __agbabi_rtc_status();
+```
+
+Resets the RTC status.
+
+```c
+void __agbabi_rtc_reset();
+```
+
+#### Modifying RTC
+
+Writes 8 bits to RTC chip.
+
+```c
+void __agbabi_rtc_write8(int n);
+```
+
 ## POSIX library
 
 ### getcontext
@@ -257,3 +309,14 @@ Alias of `__aeabi_swapcontext`.
 ```c
 int swapcontext(ucontext_t *restrict oucp, const ucontext_t *restrict ucp);
 ```
+
+### gettimeofday
+Writes the current time of day to `tv`.
+
+`tz` is unused.
+
+Returns 0 on success.
+```c
+int _gettimeofday(struct timeval* restrict tv, void* restrict tz);
+```
+This is used internally by the C time APIs.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ The argument `flags` of the `__agbabi_irq_uproc` procedure will contain a mask o
 
 Requires RTC chip on cartridge.
 
+**Important:**
+* `REG_GPIOCNT` (`0x80000c8`) must be set to `1` (read/write enabled) for RTC chip access.
+* Interrupts should be disabled during RTC chip access.
+
 #### Initialise RTC
 
 Initializes the RTC clock, returning a non-zero error code if initialization fails.
@@ -245,8 +249,6 @@ int __agbabi_rtc_init();
 ```
 
 `__agbabi_rtc_init` returns 0 on success.
-
-**The GPIO port will be left ENABLED on success.**
 
 #### Querying time
 
@@ -329,6 +331,9 @@ Returns 0 on success.
 ```c
 int _gettimeofday(struct timeval* restrict tv, struct timezone* restrict tz);
 ```
+`REG_GPIOCNT` must be set to `1`.    
+`REG_IME` is temporarily set to `0` during the RTC access.
+
 This is used internally by the C time APIs.
 
 ### settimeofday
@@ -340,3 +345,6 @@ Returns 0 on success.
 ```c
 int settimeofday(const struct timeval* restrict tv, const struct timezone* restrict tz);
 ```
+
+`REG_GPIOCNT` must be set to `1`.    
+`REG_IME` is temporarily set to `0` during the RTC access.

--- a/include/agbabi.h
+++ b/include/agbabi.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 
+#include <limits.h>
 #include <stddef.h>
 #include <sys/ucontext.h>
 
@@ -98,6 +99,61 @@ void __agbabi_irq_user();
 /// User procedure called by __agbabi_irq_user
 extern void(*__agbabi_irq_uproc)(short irqFlags);
 
+typedef enum agbabi_rtc_err_t {
+    agbabi_rtc_OK = 0,
+    agbabi_rtc_EPOWER = 1,
+    agbabi_rtc_E12HOUR = 2,
+    agbabi_rtc_EYEAR = 3,
+    agbabi_rtc_EMON = 4,
+    agbabi_rtc_EDAY = 5,
+    agbabi_rtc_EWDAY = 6,
+    agbabi_rtc_EHOUR = 7,
+    agbabi_rtc_EMIN = 8,
+    agbabi_rtc_ESEC = 9,
+
+    agbabi_rtc_ERR_SZ = INT_MAX
+} agbabi_rtc_err_t;
+
+/// Initialize GPIO pins for RTC
+/// \return agbabi_rtc_err_t error code (0 for success)
+int __agbabi_rtc_init();
+
+typedef enum agbabi_rtc_stat_t {
+    agbagbi_rtc_INTFE = 0x01,
+    agbagbi_rtc_INTME = 0x02,
+    agbagbi_rtc_INTAE = 0x04,
+    agbagbi_rtc_24HOUR = 0x40,
+    agbagbi_rtc_POWER = 0x80,
+
+    agbabi_rtc_STAT_SZ = INT_MAX
+} agbabi_rtc_stat_t;
+
+/// Get the status flags of the RTC
+/// \return bitmask of agbabi_rtc_stat_t
+int __agbabi_rtc_status();
+
+/// Resets RTC (also switches to 24-hour mode)
+void __agbabi_rtc_reset();
+
+typedef enum agbabi_rtc_time_t {
+    agbagbi_rtc_TEST = 0x80,
+
+    agbabi_rtc_TIME_SZ = INT_MAX
+} agbabi_rtc_time_t;
+
+/// Get the current, raw time from the RTC
+/// If RTC is in TEST mode: agbagbi_rtc_TEST will be set
+/// \return Raw time in BCD
+int __agbabi_rtc_time();
+
+/// Get the current, raw date & time from the RTC as a long long int
+/// \return lower 32-bits = raw time in BCD, upper 32-bits = raw date in BCD
+long long int __agbabi_rtc_ldatetime();
+
+/// Writes lowest 8 bits of n to RTC
+/// \param n data to write (lowest 8 bits used)
+void __agbabi_rtc_write8(int n);
+
 #if defined __has_attribute
 #if __has_attribute(__vector_size__)
 
@@ -127,6 +183,10 @@ unsigned long long __attribute__((__vector_size__(16))) __agbabi_uluidivmod(unsi
 /// \param denominator
 /// \return [quotient, remainder]
 unsigned long long __attribute__((__vector_size__(16))) __agbabi_unsafe_uluidivmod(unsigned long long numerator, int denominator);
+
+/// Get the current, raw date & time from the RTC
+/// \return [raw time in BCD, raw date in BCD]
+int __attribute__((__vector_size__(8))) __agbabi_rtc_datetime();
 
 #endif
 #endif

--- a/include/agbabi.h
+++ b/include/agbabi.h
@@ -146,13 +146,21 @@ typedef enum agbabi_rtc_time_t {
 /// \return Raw time in BCD
 int __agbabi_rtc_time();
 
-/// Get the current, raw date & time from the RTC as a long long int
+/// Get the current, raw date & time from the RTC as a long long
 /// \return lower 32-bits = raw time in BCD, upper 32-bits = raw date in BCD
-long long int __agbabi_rtc_ldatetime();
+long long __agbabi_rtc_ldatetime();
 
 /// Writes lowest 8 bits of n to RTC
 /// \param n data to write (lowest 8 bits used)
 void __agbabi_rtc_write8(int n);
+
+/// Set the Hour, Minute, Second
+/// \param time raw BCD (second, minute, hour)
+void __agbabi_rtc_settime(int time);
+
+/// Set the time and date
+/// \param datetime lower 32-bits = raw BCD time, upper 32-bits = raw BCD date
+void __agbabi_rtc_setldatetime(long long datetime);
 
 #if defined __has_attribute
 #if __has_attribute(__vector_size__)
@@ -187,6 +195,10 @@ unsigned long long __attribute__((__vector_size__(16))) __agbabi_unsafe_uluidivm
 /// Get the current, raw date & time from the RTC
 /// \return [raw time in BCD, raw date in BCD]
 int __attribute__((__vector_size__(8))) __agbabi_rtc_datetime();
+
+/// Set the time and date
+/// \param datetime [raw BCD time, raw BCD date]
+void __agbabi_rtc_setdatetime(int __attribute__((__vector_size__(8))) datetime);
 
 #endif
 #endif

--- a/source/rtc.c
+++ b/source/rtc.c
@@ -1,0 +1,139 @@
+/*
+===============================================================================
+
+ POSIX:
+    _gettimeofday
+
+ Support:
+    __agbabi_rtc_init
+
+ Copyright (C) 2021-2022 agbabi contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#include <agbabi.h>
+
+typedef unsigned short u16;
+typedef volatile u16 vu16;
+
+#define GPIO_PORT_READ_ENABLE ((vu16*) 0x80000c8)
+
+#define TM_YEAR(X)       (((X) >> 32) & 0xff)
+#define TM_YEAR_UNIT(X)  ((TM_YEAR(X) >> 0) & 0x0f)
+#define TM_MONTH(X)      (((X) >> 40) & 0xff)
+#define TM_MONTH_UNIT(X) ((TM_MONTH(X) >> 0) & 0x0f)
+#define TM_DAY(X)        (((X) >> 48) & 0xff)
+#define TM_DAY_UNIT(X)   ((TM_DAY(X) >> 0) & 0x0f)
+#define TM_WDAY(X)       (((X) >> 56) & 0xff)
+#define TM_WDAY_UNIT(X)  ((TM_WDAY(X) >> 0) & 0x0f)
+#define TM_HOUR(X)       (((X) >> 0) & 0xff)
+#define TM_HOUR_UNIT(X)  ((TM_HOUR(X) >> 0) & 0x0f)
+#define TM_MIN(X)        (((X) >> 8) & 0xff)
+#define TM_MIN_UNIT(X)   ((TM_MIN(X) >> 0) & 0x0f)
+#define TM_SEC(X)        (((X) >> 16) & 0xff)
+#define TM_SEC_UNIT(X)   ((TM_SEC(X) >> 0) & 0x0f)
+
+int __agbabi_rtc_init() {
+    *GPIO_PORT_READ_ENABLE = 1;
+
+    int status = __agbabi_rtc_status();
+    if ((status & agbagbi_rtc_POWER) || (status & agbagbi_rtc_24HOUR) == 0) {
+        __agbabi_rtc_reset();
+    }
+
+    const int time = __agbabi_rtc_time();
+    if (time & agbagbi_rtc_TEST) {
+        __agbabi_rtc_reset(); // Reset to leave test mode
+    }
+
+    status = __agbabi_rtc_status();
+
+    int error = 0;
+    if (status & agbagbi_rtc_POWER) {
+        error = agbabi_rtc_EPOWER;
+        goto init_error;
+    }
+
+    if ((status & agbagbi_rtc_24HOUR) == 0) {
+        error = agbabi_rtc_E12HOUR;
+        goto init_error;
+    }
+
+    const long long int datetime = __agbabi_rtc_ldatetime();
+
+    if (TM_YEAR(datetime) > 0x9f || TM_YEAR_UNIT(datetime) > 9 ) {
+        error = agbabi_rtc_EYEAR;
+        goto init_error;
+    }
+
+    if (TM_MONTH(datetime) == 0 || TM_MONTH(datetime) > 0x1f || TM_MONTH_UNIT(datetime) > 9) {
+        error = agbabi_rtc_EMON;
+        goto init_error;
+    }
+
+    if (TM_DAY(datetime) == 0 || TM_DAY(datetime) > 0x3f || TM_DAY_UNIT(datetime) > 9) {
+        error = agbabi_rtc_EDAY;
+        goto init_error;
+    }
+
+    if ((TM_WDAY(datetime) & 0xf8) || TM_WDAY_UNIT(datetime) > 6) {
+        error = agbabi_rtc_EWDAY;
+        goto init_error;
+    }
+
+    if (TM_HOUR(datetime) > 0x2f || TM_HOUR_UNIT(datetime) > 9) {
+        error = agbabi_rtc_EHOUR;
+        goto init_error;
+    }
+
+    if (TM_MIN(datetime) > 0x5f || TM_MIN_UNIT(datetime) > 9) {
+        error = agbabi_rtc_EMIN;
+        goto init_error;
+    }
+
+    if (TM_SEC(datetime) > 0x5f || TM_SEC_UNIT(datetime) > 9) {
+        error = agbabi_rtc_ESEC;
+        goto init_error;
+    }
+
+    return 0;
+
+init_error:
+    *GPIO_PORT_READ_ENABLE = 0;
+    return error;
+}
+
+#ifndef NO_POSIX
+
+#include <sys/time.h>
+
+#define bcd_decode(x) (((x) & 0xfu) + (((x) >> 4u) * 10u))
+#define REG_IME ((vu16*) 0x4000208)
+
+int _gettimeofday(struct timeval* __restrict__ tv, void* __restrict__ tz) {
+    const int ime = *REG_IME;
+    *REG_IME = 0;
+    const long long int datetime = __agbabi_rtc_ldatetime();
+    *REG_IME = ime;
+
+    struct tm time;
+    time.tm_year = bcd_decode(TM_YEAR(datetime)) + (2000u - 1900u);
+    time.tm_mon = bcd_decode(TM_MONTH(datetime)) - 1;
+    time.tm_mday = bcd_decode(TM_DAY(datetime));
+
+    time.tm_hour = bcd_decode(TM_HOUR(datetime));
+    time.tm_min = bcd_decode(TM_MIN(datetime));
+    time.tm_sec = bcd_decode(TM_SEC(datetime));
+
+    time.tm_wday = bcd_decode(TM_WDAY(datetime));
+    time.tm_yday = 0;
+    time.tm_isdst = 0;
+
+    tv->tv_usec = 0;
+    tv->tv_sec = mktime(&time);
+    return 0;
+}
+
+#endif

--- a/source/rtc.c
+++ b/source/rtc.c
@@ -50,50 +50,50 @@ int __agbabi_rtc_init() {
 
     status = __agbabi_rtc_status();
 
-    int error = 0;
-    if (status & agbagbi_rtc_POWER) {
+    int error;
+    if (__builtin_expect(status & agbagbi_rtc_POWER, 0)) {
         error = agbabi_rtc_EPOWER;
         goto init_error;
     }
 
-    if ((status & agbagbi_rtc_24HOUR) == 0) {
+    if (!__builtin_expect(status & agbagbi_rtc_24HOUR, agbagbi_rtc_24HOUR)) {
         error = agbabi_rtc_E12HOUR;
         goto init_error;
     }
 
-    const long long int datetime = __agbabi_rtc_ldatetime();
+    const long long datetime = __agbabi_rtc_ldatetime();
 
-    if (TM_YEAR(datetime) > 0x9f || TM_YEAR_UNIT(datetime) > 9 ) {
+    if (__builtin_expect(TM_YEAR(datetime) > 0x9f || TM_YEAR_UNIT(datetime) > 9, 1)) {
         error = agbabi_rtc_EYEAR;
         goto init_error;
     }
 
-    if (TM_MONTH(datetime) == 0 || TM_MONTH(datetime) > 0x1f || TM_MONTH_UNIT(datetime) > 9) {
+    if (__builtin_expect(TM_MONTH(datetime) == 0 || TM_MONTH(datetime) > 0x1f || TM_MONTH_UNIT(datetime) > 9, 1)) {
         error = agbabi_rtc_EMON;
         goto init_error;
     }
 
-    if (TM_DAY(datetime) == 0 || TM_DAY(datetime) > 0x3f || TM_DAY_UNIT(datetime) > 9) {
+    if (__builtin_expect(TM_DAY(datetime) == 0 || TM_DAY(datetime) > 0x3f || TM_DAY_UNIT(datetime) > 9, 1)) {
         error = agbabi_rtc_EDAY;
         goto init_error;
     }
 
-    if ((TM_WDAY(datetime) & 0xf8) || TM_WDAY_UNIT(datetime) > 6) {
+    if (__builtin_expect((TM_WDAY(datetime) & 0xf8) || TM_WDAY_UNIT(datetime) > 6, 1)) {
         error = agbabi_rtc_EWDAY;
         goto init_error;
     }
 
-    if (TM_HOUR(datetime) > 0x2f || TM_HOUR_UNIT(datetime) > 9) {
+    if (__builtin_expect(TM_HOUR(datetime) > 0x2f || TM_HOUR_UNIT(datetime) > 9, 1)) {
         error = agbabi_rtc_EHOUR;
         goto init_error;
     }
 
-    if (TM_MIN(datetime) > 0x5f || TM_MIN_UNIT(datetime) > 9) {
+    if (__builtin_expect(TM_MIN(datetime) > 0x5f || TM_MIN_UNIT(datetime) > 9, 1)) {
         error = agbabi_rtc_EMIN;
         goto init_error;
     }
 
-    if (TM_SEC(datetime) > 0x5f || TM_SEC_UNIT(datetime) > 9) {
+    if (__builtin_expect(TM_SEC(datetime) > 0x5f || TM_SEC_UNIT(datetime) > 9, 1)) {
         error = agbabi_rtc_ESEC;
         goto init_error;
     }
@@ -109,30 +109,64 @@ init_error:
 
 #include <sys/time.h>
 
-#define bcd_decode(x) (((x) & 0xfu) + (((x) >> 4u) * 10u))
+#define BCD_DECODE(X) (((X) & 0xfu) + (((X) >> 4u) * 10u))
+#define BCD_ENCODE(X) (((X) % 10) + (((X) / 10) << 4))
+
+#define MAKE_YEAR(X)  (((long long) (X)) << 32)
+#define MAKE_MONTH(X) (((long long) (X)) << 40)
+#define MAKE_DAY(X)   (((long long) (X)) << 48)
+#define MAKE_WDAY(X)  (((long long) (X)) << 56)
+#define MAKE_HOUR(X)  (((long long) (X)) << 0)
+#define MAKE_MIN(X)   (((long long) (X)) << 8)
+#define MAKE_SEC(X)   (((long long) (X)) << 16)
+
 #define REG_IME ((vu16*) 0x4000208)
 
-int _gettimeofday(struct timeval* __restrict__ tv, void* __restrict__ tz) {
+int _gettimeofday(struct timeval* __restrict__ tv, __attribute__((unused)) struct timezone* tz) {
     const int ime = *REG_IME;
     *REG_IME = 0;
-    const long long int datetime = __agbabi_rtc_ldatetime();
+    const long long datetime = __agbabi_rtc_ldatetime();
     *REG_IME = ime;
 
     struct tm time;
-    time.tm_year = bcd_decode(TM_YEAR(datetime)) + (2000u - 1900u);
-    time.tm_mon = bcd_decode(TM_MONTH(datetime)) - 1;
-    time.tm_mday = bcd_decode(TM_DAY(datetime));
+    time.tm_year = BCD_DECODE(TM_YEAR(datetime)) + (2000 - 1900);
+    time.tm_mon = BCD_DECODE(TM_MONTH(datetime)) - 1;
+    time.tm_mday = BCD_DECODE(TM_DAY(datetime));
 
-    time.tm_hour = bcd_decode(TM_HOUR(datetime));
-    time.tm_min = bcd_decode(TM_MIN(datetime));
-    time.tm_sec = bcd_decode(TM_SEC(datetime));
+    time.tm_hour = BCD_DECODE(TM_HOUR(datetime));
+    time.tm_min = BCD_DECODE(TM_MIN(datetime));
+    time.tm_sec = BCD_DECODE(TM_SEC(datetime));
 
-    time.tm_wday = bcd_decode(TM_WDAY(datetime));
+    time.tm_wday = BCD_DECODE(TM_WDAY(datetime));
     time.tm_yday = 0;
     time.tm_isdst = 0;
 
     tv->tv_usec = 0;
     tv->tv_sec = mktime(&time);
+    return 0;
+}
+
+int settimeofday(const struct timeval* __restrict__ tv, __attribute__((unused)) const struct timezone* __restrict__ tz) {
+    const struct tm* tmptr = gmtime(&tv->tv_sec);
+
+    const int year = BCD_ENCODE(tmptr->tm_year - (2000 - 1900));
+    const int mon = BCD_ENCODE(tmptr->tm_mon) + 1;
+    const int mday = BCD_ENCODE(tmptr->tm_mday);
+
+    const int wday = BCD_ENCODE(tmptr->tm_wday);
+
+    const int hour = BCD_ENCODE(tmptr->tm_hour);
+    const int min = BCD_ENCODE(tmptr->tm_min);
+    const int sec = BCD_ENCODE(tmptr->tm_sec);
+
+    const long long datetime = MAKE_YEAR(year) | MAKE_MONTH(mon) | MAKE_DAY(mday) |
+            MAKE_WDAY(wday) | MAKE_HOUR(hour) | MAKE_MIN(min) | MAKE_SEC(sec);
+
+    const int ime = *REG_IME;
+    *REG_IME = 0;
+    __agbabi_rtc_setldatetime(datetime);
+    *REG_IME = ime;
+
     return 0;
 }
 

--- a/source/rtc.s
+++ b/source/rtc.s
@@ -190,7 +190,7 @@ __agbabi_rtc_time:
     mov     r0, #0
 
     .set i, 0
-    .rept 24
+    .rept 23
         strh    r2, [r3]
         strh    r2, [r3]
         strh    r2, [r3]
@@ -204,19 +204,19 @@ __agbabi_rtc_time:
         orr     r0, r1
 
         .set i, i + 1
-        .if i < 24
+        .if i < 23
             sub     r2, r2, #1
             lsr     r0, #1
         .endif
     .endr
 
-    lsr     r0, #8
+    lsr     r0, #9
 
     mov     r1, #1
     strh    r1, [r3]
     strh    r1, [r3]
 
-    lsl     r1, #22
+    lsl     r1, #23
     bic     r0, r1
 
     pop     {r1}
@@ -276,17 +276,21 @@ __agbabi_rtc_datetime:
         add     r2, r2, #1
         strh    r2, [r3]
 
-        ldrh    r1, [r3]
-        lsl     r1, #30
-        orr     r0, r1
-
         .set i, i + 1
+        .if i < 28
+            ldrh    r1, [r3]
+            lsl     r1, #30
+            orr     r0, r1
+
+            lsr     r0, #1
+        .endif
+
         .if i < 32
             sub     r2, r2, #1
-            lsr     r0, #1
         .endif
     .endr
 
+    lsr     r0, #4
     push    {r0}
 
     // read24
@@ -294,7 +298,7 @@ __agbabi_rtc_datetime:
     mov     r0, #0
 
     .set i, 0
-    .rept 24
+    .rept 23
         strh    r2, [r3]
         strh    r2, [r3]
         strh    r2, [r3]
@@ -308,19 +312,19 @@ __agbabi_rtc_datetime:
         orr     r0, r1
 
         .set i, i + 1
-        .if i < 24
+        .if i < 23
             sub     r2, r2, #1
             lsr     r0, #1
         .endif
     .endr
 
-    lsr     r0, #8
+    lsr     r0, #9
 
     mov     r1, #1
     strh    r1, [r3]
     strh    r1, [r3]
 
-    lsl     r1, #22
+    lsl     r1, #23
     bic     r0, r1
 
     pop     {r1, r2}
@@ -350,7 +354,7 @@ __agbabi_rtc_settime:
     lsl     r0, #1
 
     .set i, 0
-    .rept 24
+    .rept 23
         mov     r2, #2
         and     r2, r0
         add     r1, r2, #4
@@ -361,7 +365,7 @@ __agbabi_rtc_settime:
         strh    r2, [r3]
 
         .set i, i + 1
-        .if i < 24
+        .if i < 23
             lsr     r0, #1
         .endif
     .endr
@@ -416,17 +420,22 @@ __agbabi_rtc_setdatetime:
     // Set 24 bits of time (repeat the 25th bit 8 times for 32-bit alignment)
     .set i, 0
     .rept 32
-        mov     r2, #2
-        and     r2, r0
-        add     r1, r2, #4
-        add     r2, r1, #1
+        .if i < 24
+            mov     r2, #2
+            and     r2, r0
+            add     r1, r2, #4
+            add     r2, r1, #1
+        .elseif i == 24
+            mov     r1, #6
+            mov     r2, #7
+        .endif
         strh    r1, [r3]
         strh    r1, [r3]
         strh    r1, [r3]
         strh    r2, [r3]
 
         .set i, i + 1
-        .if i < 24
+        .if i < 23
             lsr     r0, #1
         .endif
     .endr

--- a/source/rtc.s
+++ b/source/rtc.s
@@ -3,7 +3,8 @@
 
  Support:
     __agbabi_rtc_write8 __agbabi_rtc_reset, __agbabi_rtc_status,
-    __agbabi_rtc_time, __agbabi_rtc_ldatetime, __agbabi_rtc_datetime
+    __agbabi_rtc_time, __agbabi_rtc_ldatetime, __agbabi_rtc_datetime,
+    __agbabi_rtc_settime, __agbabi_rtc_setldatetime, __agbabi_rtc_setdatetime
 
  Copyright (C) 2021-2022 agbabi contributors
  For conditions of distribution and use, see copyright notice in LICENSE.md
@@ -324,3 +325,136 @@ __agbabi_rtc_datetime:
 
     pop     {r1, r2}
     bx      r2
+
+    .section .text.__agbabi_rtc_settime, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_settime
+__agbabi_rtc_settime:
+    push    {r0, lr}
+
+    ldr     r3, .Lsettime_GPIO_PORT_DATA
+    ldr     r2, .Lsettime_GPIO_PORT_DIRECTION
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r2, r3}
+    mov     r0, #(CMD_TIME_WRITE)
+    bl      __agbabi_rtc_write8
+    pop     {r2, r3}
+
+    pop     {r0}
+    lsl     r0, #1
+
+    .set i, 0
+    .rept 24
+        mov     r2, #2
+        and     r2, r0
+        add     r1, r2, #4
+        add     r2, r1, #1
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r2, [r3]
+
+        .set i, i + 1
+        .if i < 24
+            lsr     r0, #1
+        .endif
+    .endr
+
+    mov     r1, #1
+    strh    r1, [r3]
+    strh    r1, [r3]
+
+    pop     {r1}
+    bx      r1
+    .align 2
+.Lsettime_GPIO_PORT_DATA:
+    .long   0x80000c4
+.Lsettime_GPIO_PORT_DIRECTION:
+    .long   0x80000c6
+
+    .section .text.__agbabi_rtc_setdatetime, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_setldatetime
+__agbabi_rtc_setldatetime:
+    .global __agbabi_rtc_setdatetime
+__agbabi_rtc_setdatetime:
+    push    {r0, r1, lr}
+
+    ldr     r3, .Lsetdatetime_GPIO_PORT_DATA
+    ldr     r2, .Lsetdatetime_GPIO_PORT_DIRECTION
+    b       .Lsetdatetime_after_GPIO
+
+    .align 2
+.Lsetdatetime_GPIO_PORT_DATA:
+    .long   0x80000c4
+.Lsetdatetime_GPIO_PORT_DIRECTION:
+    .long   0x80000c6
+    .align 2
+.Lsetdatetime_after_GPIO:
+
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r2, r3}
+    mov     r0, #(CMD_DATETIME_WRITE)
+    bl      __agbabi_rtc_write8
+    pop     {r2, r3}
+
+    pop     {r0}
+    lsl     r0, #1
+
+    // Set 24 bits of time (repeat the 25th bit 8 times for 32-bit alignment)
+    .set i, 0
+    .rept 32
+        mov     r2, #2
+        and     r2, r0
+        add     r1, r2, #4
+        add     r2, r1, #1
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r2, [r3]
+
+        .set i, i + 1
+        .if i < 24
+            lsr     r0, #1
+        .endif
+    .endr
+
+    pop     {r0}
+    lsl     r0, #1
+
+    // Set 27 bits of date (24-bits for date, plus day of week consumes 3 bits)
+    .set i, 0
+    .rept 27
+        mov     r2, #2
+        and     r2, r0
+        add     r1, r2, #4
+        add     r2, r1, #1
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r2, [r3]
+
+        .set i, i + 1
+        .if i < 27
+            lsr     r0, #1
+        .endif
+    .endr
+
+    mov     r1, #1
+    strh    r1, [r3]
+    strh    r1, [r3]
+
+    pop     {r1}
+    bx      r1

--- a/source/rtc.s
+++ b/source/rtc.s
@@ -1,0 +1,326 @@
+/*
+===============================================================================
+
+ Support:
+    __agbabi_rtc_write8 __agbabi_rtc_reset, __agbabi_rtc_status,
+    __agbabi_rtc_time, __agbabi_rtc_ldatetime, __agbabi_rtc_datetime
+
+ Copyright (C) 2021-2022 agbabi contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#define CMD_RESET          0x06
+#define CMD_STATUS_WRITE   0x46
+#define CMD_DATETIME_WRITE 0x26
+#define CMD_TIME_WRITE     0x66
+
+#define CMD_STATUS_READ   0xc6
+#define CMD_DATETIME_READ 0xa6
+#define CMD_TIME_READ     0xe6
+
+    .align 2
+
+    .section .text.__agbabi_rtc_write8, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_write8
+__agbabi_rtc_write8:
+    ldr     r3, .Lwrite8_GPIO_PORT_DATA
+    lsl     r0, #1
+
+    .set i, 0
+    .rept 8
+        mov     r2, #2
+        and     r2, r0
+        add     r1, r2, #4
+        add     r2, r1, #1
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r1, [r3]
+        strh    r2, [r3]
+
+        .set i, i + 1
+        .if i < 8
+            lsr     r0, #1
+        .endif
+    .endr
+
+    bx      lr
+    .align 2
+.Lwrite8_GPIO_PORT_DATA:
+    .long   0x80000c4
+
+    .section .text.__agbabi_rtc_reset, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_reset
+__agbabi_rtc_reset:
+    push    {lr}
+
+    ldr     r3, .Lreset_GPIO_PORT_DATA
+    ldr     r2, .Lreset_GPIO_PORT_DIRECTION
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r2, r3}
+    mov     r0, #(CMD_RESET)
+    bl      __agbabi_rtc_write8
+    pop     {r2, r3}
+
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r0, [r3]
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r3}
+    mov     r0, #(CMD_STATUS_WRITE)
+    bl      __agbabi_rtc_write8
+    mov     r0, #0x40
+    bl      __agbabi_rtc_write8
+    pop     {r3}
+
+    mov     r0, #1
+    strh    r0, [r3]
+    strh    r0, [r3]
+
+    pop     {r0}
+    bx      r0
+    .align 2
+.Lreset_GPIO_PORT_DATA:
+    .long   0x80000c4
+.Lreset_GPIO_PORT_DIRECTION:
+    .long   0x80000c6
+
+    .section .text.__agbabi_rtc_status, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_status
+__agbabi_rtc_status:
+    push    {lr}
+
+    ldr     r3, .Lstatus_GPIO_PORT_DATA
+    ldr     r2, .Lstatus_GPIO_PORT_DIRECTION
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r2, r3}
+    mov     r0, #(CMD_STATUS_READ)
+    bl      __agbabi_rtc_write8
+    pop     {r2, r3}
+
+    mov     r1, #5
+    strh    r1, [r2]
+
+    // read8
+    mov     r2, #4
+    mov     r0, #0
+
+    .set i, 0
+    .rept 8
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        add     r2, r2, #1
+        strh    r2, [r3]
+
+        ldrh    r1, [r3]
+        lsl     r1, #30
+        orr     r0, r1
+
+        .set i, i + 1
+        .if i < 8
+            sub     r2, r2, #1
+            lsr     r0, #1
+        .endif
+    .endr
+
+    lsr     r0, #24
+
+    mov     r1, #1
+    strh    r1, [r3]
+    strh    r1, [r3]
+
+    pop     {r1}
+    bx      r1
+    .align 2
+.Lstatus_GPIO_PORT_DATA:
+    .long   0x80000c4
+.Lstatus_GPIO_PORT_DIRECTION:
+    .long   0x80000c6
+
+    .section .text.__agbabi_rtc_time, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_time
+__agbabi_rtc_time:
+    push    {lr}
+
+    ldr     r3, .Ltime_GPIO_PORT_DATA
+    ldr     r2, .Ltime_GPIO_PORT_DIRECTION
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r2, r3}
+    mov     r0, #(CMD_TIME_READ)
+    bl      __agbabi_rtc_write8
+    pop     {r2, r3}
+
+    mov     r1, #5
+    strh    r1, [r2]
+
+    // read24
+    mov     r2, #4
+    mov     r0, #0
+
+    .set i, 0
+    .rept 24
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        add     r2, r2, #1
+        strh    r2, [r3]
+
+        ldrh    r1, [r3]
+        lsl     r1, #30
+        orr     r0, r1
+
+        .set i, i + 1
+        .if i < 24
+            sub     r2, r2, #1
+            lsr     r0, #1
+        .endif
+    .endr
+
+    lsr     r0, #8
+
+    mov     r1, #1
+    strh    r1, [r3]
+    strh    r1, [r3]
+
+    lsl     r1, #22
+    bic     r0, r1
+
+    pop     {r1}
+    bx      r1
+    .align 2
+.Ltime_GPIO_PORT_DATA:
+    .long   0x80000c4
+.Ltime_GPIO_PORT_DIRECTION:
+    .long   0x80000c6
+
+    .section .text.__agbabi_rtc_datetime, "ax", %progbits
+    .thumb_func
+    .global __agbabi_rtc_ldatetime
+__agbabi_rtc_ldatetime:
+    .global __agbabi_rtc_datetime
+__agbabi_rtc_datetime:
+    push    {lr}
+
+    ldr     r3, .Ldatetime_GPIO_PORT_DATA
+    ldr     r2, .Ldatetime_GPIO_PORT_DIRECTION
+    b       .Ldatetime_after_GPIO
+
+    .align 2
+.Ldatetime_GPIO_PORT_DATA:
+    .long   0x80000c4
+.Ldatetime_GPIO_PORT_DIRECTION:
+    .long   0x80000c6
+    .align 2
+.Ldatetime_after_GPIO:
+
+    mov     r0, #1
+    add     r1, r0, #4
+    strh    r0, [r3]
+    strh    r1, [r3]
+    add     r1, r1, #2
+    strh    r1, [r2]
+
+    push    {r2, r3}
+    mov     r0, #(CMD_DATETIME_READ)
+    bl      __agbabi_rtc_write8
+    pop     {r2, r3}
+
+    mov     r1, #5
+    strh    r1, [r2]
+
+    // read32
+    mov     r2, #4
+    mov     r0, #0
+
+    .set i, 0
+    .rept 32
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        add     r2, r2, #1
+        strh    r2, [r3]
+
+        ldrh    r1, [r3]
+        lsl     r1, #30
+        orr     r0, r1
+
+        .set i, i + 1
+        .if i < 32
+            sub     r2, r2, #1
+            lsr     r0, #1
+        .endif
+    .endr
+
+    push    {r0}
+
+    // read24
+    mov     r2, #4
+    mov     r0, #0
+
+    .set i, 0
+    .rept 24
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        strh    r2, [r3]
+        add     r2, r2, #1
+        strh    r2, [r3]
+
+        ldrh    r1, [r3]
+        lsl     r1, #30
+        orr     r0, r1
+
+        .set i, i + 1
+        .if i < 24
+            sub     r2, r2, #1
+            lsr     r0, #1
+        .endif
+    .endr
+
+    lsr     r0, #8
+
+    mov     r1, #1
+    strh    r1, [r3]
+    strh    r1, [r3]
+
+    lsl     r1, #22
+    bic     r0, r1
+
+    pop     {r1, r2}
+    bx      r2


### PR DESCRIPTION
Includes POSIX `gettimeofday`, which is used by C time, and the BSD `_settimeofday` (requires manually forward declaring).

[Sample usage here](https://github.com/felixjones/gba-toolchain/blob/5fde836a8e97e9bb2cc6bef944826474134fa813/samples/9%20RTC/main.c)