### PR TITLE
Support for devkitARM toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,3 +38,7 @@ target_compile_options(agbabi PRIVATE
     $<$<COMPILE_LANGUAGE:ASM>:-x assembler-with-cpp>
     $<$<COMPILE_LANGUAGE:C>:-mabi=aapcs -march=armv4t -mcpu=arm7tdmi -mthumb -ffunction-sections -fdata-sections -Wall -Wextra -Wno-unused-parameter>
 )
+
+if(USE_DEVKITARM)
+    target_compile_definitions(agbabi PRIVATE __DEVKITARM__)
+endif()

--- a/include/sys/ucontext.h
+++ b/include/sys/ucontext.h
@@ -19,10 +19,14 @@ extern "C" {
 
 #include <stddef.h>
 
+#if defined(__DEVKITARM__)
+#   include <sys/signal.h>
+#else
 typedef struct stack_t {
     void* ss_sp;
     size_t ss_size;
 } stack_t;
+#endif
 
 typedef struct mcontext_t {
     unsigned int arm_r0;
@@ -80,7 +84,11 @@ void makecontext(ucontext_t* ucp, void(*func)(), int argc, ...);
 #endif // ifndef __ASSEMBLER__
 
 #define STACK_OFFSETOF_SS_SP 0
-#define STACK_OFFSETOF_SS_SIZE 4
+#if defined(__DEVKITARM__)
+#   define STACK_OFFSETOF_SS_SIZE 8
+#else
+#   define STACK_OFFSETOF_SS_SIZE 4
+#endif
 
 #define MCONTEXT_OFFSETOF_ARM_R0 0
 #define MCONTEXT_OFFSETOF_ARM_R1 4
@@ -102,7 +110,11 @@ void makecontext(ucontext_t* ucp, void(*func)(), int argc, ...);
 
 #define UCONTEXT_OFFSETOF_UC_LINK 0
 #define UCONTEXT_OFFSETOF_UC_STACK 4
-#define UCONTEXT_OFFSETOF_UC_MCONTEXT 12
+#if defined(__DEVKITARM__)
+#   define UCONTEXT_OFFSETOF_UC_MCONTEXT 16
+#else
+#   define UCONTEXT_OFFSETOF_UC_MCONTEXT 12
+#endif
 
 #if defined( __cplusplus )
 } // extern "C"

--- a/source/rtc.c
+++ b/source/rtc.c
@@ -128,6 +128,12 @@ int _gettimeofday(struct timeval* __restrict__ tv, __attribute__((unused)) struc
     return 0;
 }
 
+#if defined(__DEVKITARM__)
+int _gettimeofday_r(__attribute__((unused)) void* __restrict__ reent, struct timeval* __restrict__ tv, __attribute__((unused)) struct timezone* tz) {
+    return _gettimeofday(tv, tz);
+}
+#endif
+
 int settimeofday(const struct timeval* __restrict__ tv, __attribute__((unused)) const struct timezone* __restrict__ tz) {
     const struct tm* tmptr = gmtime(&tv->tv_sec);
 


### PR DESCRIPTION
devkitARM provides `sys/signal.h` (for some reason) so we can use that for `stack_t` (increases size by 4 bytes)
devkitARM uses reentrant POSIX API functions (for some reason) so we need `_gettimeofday_r` for C time API
Must be compiled with `-D__DEVKITARM__` (is there a better macro to use?)