### PR TITLE
meson.build: add minimum meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('agbabi', 'c',
   version: '2.0.0',
   license: 'Zlib',
+  meson_version: '>=0.54.0',
   default_options: ['warning_level=2'])
 
 sources_asm = [


### PR DESCRIPTION
the newest feature used is meson.override_dependency, added in 0.54.0