### PR TITLE
Small test suite to identify regressions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@
 #===============================================================================
 
 project('agbabi', 'c',
-  version: '2.1.1',
+  version: '2.1.2',
   license: 'Zlib',
   meson_version: '>=0.56.2',
   default_options: [

--- a/source/memset.s
+++ b/source/memset.s
@@ -43,7 +43,8 @@ __aeabi_memset:
     joaobapt_test r3
     strmib  r2, [r0], #1
     submi   r1, r1, #1
-    strcsh  r2, [r0], #2
+    strcsb  r2, [r0], #1
+    strcsb  r2, [r0], #1
     subcs   r1, r1, #2
 
     .global __aeabi_memset8

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(agbabi_test ASM C)
+
+# Use local agbabi
+add_subdirectory(.. ${CMAKE_BINARY_DIR}/lib/agbabi)
+
+find_package(librom)
+find_package(tonclib)
+find_package(posprintf)
+
+add_executable(agbabi_test main.c
+    test_memcpy.c
+    test_memset.c
+)
+target_compile_options(agbabi_test PRIVATE -mthumb -Wpedantic -Wall -Wextra -Wconversion)
+target_link_libraries(agbabi_test PRIVATE librom agbabi tonclib posprintf)
+
+set_target_properties(agbabi_test PROPERTIES
+    ROM_TITLE "AGBABI test"
+    ROM_ID AATE
+    ROM_MAKER FJ
+    ROM_VERSION 1
+)
+
+install_rom(agbabi_test)

--- a/test/CMakePresets.json
+++ b/test/CMakePresets.json
@@ -1,0 +1,21 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/cmake-build-debug",
+      "installDir": "${sourceDir}/rom/debug",
+      "toolchainFile": "${sourceDir}/../../../../cmake/agb.toolchain.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ]
+}

--- a/test/agbtest.h
+++ b/test/agbtest.h
@@ -1,0 +1,68 @@
+#include <malloc.h>
+#include <stddef.h>
+
+extern void posprintf(char *, const char *, ...);
+
+typedef void (*agbtest_fun)(char* agbtest_output, int* agbtest_result);
+typedef void (*agbtest_callback_fun)(const char* name, int failed, const char* message);
+
+struct agbtest_test {
+    const char* name;
+    agbtest_fun func;
+};
+
+struct agbtest_state {
+    size_t num_tests;
+    struct agbtest_test* tests;
+    agbtest_callback_fun callback;
+};
+
+#define AGBTEST_CTOR(F)  \
+  static void F(void) __attribute__((constructor)); \
+  static void F(void)
+
+#define AGBTEST(SET, NAME) \
+    extern struct agbtest_state agbtest_set_##SET; \
+    static void agbtest_run_##SET##_##NAME(char* agbtest_output, int* agbtest_result); \
+    AGBTEST_CTOR(agbtest_add_##SET##_##NAME) { \
+        const size_t idx = agbtest_set_##SET.num_tests++; \
+        agbtest_set_##SET.tests = (struct agbtest_test*) realloc(agbtest_set_##SET.tests, sizeof(struct agbtest_test) * agbtest_set_##SET.num_tests); \
+        agbtest_set_##SET.tests[idx].name = #SET ":" #NAME; \
+        agbtest_set_##SET.tests[idx].func = &agbtest_run_##SET##_##NAME; \
+    } \
+    void agbtest_run_##SET##_##NAME(char* agbtest_output, int* agbtest_result)
+
+#define AGBTEST_SET(SET, CALLBACK) struct agbtest_state agbtest_set_##SET = {0, NULL, CALLBACK}
+
+static inline void agbtest_run(const struct agbtest_state* set) {
+    char message[80];
+    for (size_t i = 0; i < set->num_tests; ++i) {
+        int result = 0;
+        set->tests[i].func(message, &result);
+        set->callback(set->tests[i].name, result, message);
+    }
+}
+
+#define AGBTEST_RUN(SET) agbtest_run(&agbtest_set_##SET)
+
+#define ASSERT_FAIL do {(*agbtest_result) = 1; return;} while(0)
+
+#define ASSERT_MEMCMP(BUF, TYPE, ...) \
+    do { \
+        static const TYPE TMP[] = {__VA_ARGS__}; \
+        const char* tmp = (const char*) TMP; \
+        const char* buf = (const char*) BUF; \
+        for (size_t i = 0; i < sizeof(TMP); ++i) { \
+            if (buf[i] != tmp[i]) { \
+                posprintf(agbtest_output, "Byte %d expected 0x%02x got 0x%02x", i, tmp[i], buf[i]); \
+                ASSERT_FAIL; \
+                break; \
+            } \
+        } \
+    } while(0)
+
+#define ASSERT_EQUAL(A, B) \
+    do { \
+        posprintf(agbtest_output, "Expected %d == %d", A, B); \
+        if ((A) != (B)) ASSERT_FAIL; \
+    } while (0)

--- a/test/main.c
+++ b/test/main.c
@@ -1,0 +1,49 @@
+#include <tonc.h>
+#include <agbabi.h>
+#include <aeabi.h>
+
+#include "agbtest.h"
+
+static void test_callback(const char* name, int result, const char* message);
+
+AGBTEST_SET(memcpy, test_callback);
+AGBTEST_SET(memset, test_callback);
+
+int main(void) {
+    irq_init(NULL);
+    irq_add(II_VBLANK, NULL);
+    REG_DISPCNT = DCNT_MODE0 | DCNT_BG0;
+    REG_BG0HOFS = 248;
+    REG_BG0VOFS = 248;
+
+    tte_init_se(0, BG_CBB(0) | BG_SBB(31), 0, CLR_YELLOW, 14, NULL, NULL);
+
+    pal_bg_bank[1][15] = CLR_RED;
+    pal_bg_bank[2][15] = CLR_GREEN;
+    pal_bg_bank[3][15] = CLR_BLUE;
+    pal_bg_bank[4][15] = CLR_WHITE;
+    pal_bg_bank[5][15] = CLR_MAG;
+
+    tte_erase_screen();
+
+    tte_write("memcpy ");
+    AGBTEST_RUN(memcpy);
+    tte_write("\n");
+
+    tte_write("memset ");
+    AGBTEST_RUN(memset);
+    tte_write("\n");
+
+    key_wait_till_hit(KEY_ANY);
+}
+
+void test_callback(const char* name, int failed, const char* message) {
+    if (failed) {
+        tte_write("X\n");
+        tte_write(name);
+        tte_write("\n");
+        tte_write(message);
+    } else {
+        tte_write("O");
+    }
+}

--- a/test/test_memcpy.c
+++ b/test/test_memcpy.c
@@ -1,0 +1,67 @@
+#include <aeabi.h>
+
+#include "agbtest.h"
+
+static void fill_ascii_buffer(void* buf, size_t len, char base);
+
+#define MEMCPY_TEST(TYPE, OFFSRC, OFFDST, ...) \
+    AGBTEST(memcpy, TYPE##_offset_##OFFSRC##_##OFFDST) { \
+        static const size_t len = 8; \
+        char dest[len]; \
+        fill_ascii_buffer(dest, len, 'a'); \
+        char src[len]; \
+        fill_ascii_buffer(src, len, 'A'); \
+        __aeabi_memcpy(&dest[OFFSRC], &src[OFFDST], sizeof(TYPE)); \
+        ASSERT_MEMCMP(dest, char, __VA_ARGS__); \
+    }
+
+MEMCPY_TEST(char, 0, 0, 'A', 'b', 'c', 'd')
+MEMCPY_TEST(char, 0, 1, 'B', 'b', 'c', 'd')
+MEMCPY_TEST(char, 1, 0, 'a', 'A', 'c', 'd')
+MEMCPY_TEST(char, 1, 1, 'a', 'B', 'c', 'd')
+
+MEMCPY_TEST(short, 0, 0, 'A', 'B', 'c', 'd')
+MEMCPY_TEST(short, 0, 1, 'B', 'C', 'c', 'd')
+MEMCPY_TEST(short, 1, 0, 'a', 'A', 'B', 'd')
+MEMCPY_TEST(short, 1, 1, 'a', 'B', 'C', 'd')
+MEMCPY_TEST(short, 0, 2, 'C', 'D', 'c', 'd')
+MEMCPY_TEST(short, 2, 0, 'a', 'b', 'A', 'B')
+
+MEMCPY_TEST(int, 0, 0, 'A', 'B', 'C', 'D', 'e', 'f', 'g', 'h')
+MEMCPY_TEST(int, 0, 1, 'B', 'C', 'D', 'E', 'e', 'f', 'g', 'h')
+MEMCPY_TEST(int, 1, 0, 'a', 'A', 'B', 'C', 'D', 'f', 'g', 'h')
+MEMCPY_TEST(int, 1, 1, 'a', 'B', 'C', 'D', 'E', 'f', 'g', 'h')
+MEMCPY_TEST(int, 0, 2, 'C', 'D', 'E', 'F', 'e', 'f', 'g', 'h')
+MEMCPY_TEST(int, 2, 0, 'a', 'b', 'A', 'B', 'C', 'D', 'g', 'h')
+MEMCPY_TEST(int, 0, 3, 'D', 'E', 'F', 'G', 'e', 'f', 'g', 'h')
+MEMCPY_TEST(int, 3, 0, 'a', 'b', 'c', 'A', 'B', 'C', 'D', 'h')
+MEMCPY_TEST(int, 1, 3, 'a', 'D', 'E', 'F', 'G', 'f', 'g', 'h')
+MEMCPY_TEST(int, 3, 1, 'a', 'b', 'c', 'B', 'C', 'D', 'E', 'h')
+
+AGBTEST(memcpy, struct) {
+    struct test_struct {
+        unsigned short a;
+        char b[8];
+        char c : 7;
+        char d : 1;
+    };
+
+    struct test_struct dest = {0xcdcdu, {0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd}, 0x4d, 1};
+
+    char src[8];
+    fill_ascii_buffer(src, 8, 'a');
+
+    __aeabi_memcpy(&dest.b[0], src, 7);
+    ASSERT_EQUAL(dest.a, 0xcdcd);
+    ASSERT_MEMCMP(&dest.b[0], char, 'a', 'b', 'c', 'd', 'e', 'f', 'g');
+    ASSERT_EQUAL(dest.b[7], 0xcd);
+    ASSERT_EQUAL(dest.c, 0x4d);
+    ASSERT_EQUAL(dest.d, 1);
+}
+
+void fill_ascii_buffer(void* buf, size_t len, char base) {
+    char* b = (char*) buf;
+    for (size_t i = 0; i < len; ++i) {
+        b[i] = (char) (base + (i % 26));
+    }
+}

--- a/test/test_memset.c
+++ b/test/test_memset.c
@@ -1,0 +1,90 @@
+#include <aeabi.h>
+
+#include "agbtest.h"
+
+static void fill_ascii_buffer(void* buf, size_t len, char base);
+
+AGBTEST(memset, byte) {
+    unsigned char b = 0xff;
+    __aeabi_memset(&b, 1, 0xcd);
+    ASSERT_EQUAL(b, 0xcd);
+}
+
+AGBTEST(memset, short) {
+    unsigned short b = 0xffff;
+    __aeabi_memset(&b, 2, 0xcd);
+    ASSERT_EQUAL(b, 0xcdcd);
+}
+
+AGBTEST(memset, int) {
+    unsigned int b = 0xffffffff;
+    __aeabi_memset(&b, 4, 0xcd);
+    ASSERT_EQUAL(b, 0xcdcdcdcd);
+}
+
+AGBTEST(memset, int64) {
+    unsigned long long b = 0xffffffffffffffffULL;
+    __aeabi_memset(&b, 8, 0xcd);
+    ASSERT_EQUAL(b, 0xcdcdcdcdcdcdcdcdULL);
+}
+
+AGBTEST(memset, offset_1) {
+    char b[8];
+    fill_ascii_buffer(b, 8, 'a');
+
+    __aeabi_memset(&b[1], 4, '?');
+    ASSERT_MEMCMP(b, char, 'a', '?', '?', '?', '?', 'f', 'g', 'h');
+}
+
+AGBTEST(memset, offset_2) {
+    char b[8];
+    fill_ascii_buffer(b, 8, 'a');
+
+    __aeabi_memset(&b[2], 4, '?');
+    ASSERT_MEMCMP(b, char, 'a', 'b', '?', '?', '?', '?', 'g', 'h');
+}
+
+AGBTEST(memset, offset_3) {
+    char b[8];
+    fill_ascii_buffer(b, 8, 'a');
+
+    __aeabi_memset(&b[3], 4, '?');
+    ASSERT_MEMCMP(b, char, 'a', 'b', 'c', '?', '?', '?', '?', 'h');
+}
+
+AGBTEST(memset, big_offset_1) {
+    char b[26];
+    fill_ascii_buffer(b, 26, 'a');
+
+    __aeabi_memset(&b[1], 16, '?');
+    ASSERT_MEMCMP(b, char, 'a',
+                  '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
+                  'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z');
+}
+
+AGBTEST(memset, big_offset_2) {
+    char b[26];
+    fill_ascii_buffer(b, 26, 'a');
+
+    __aeabi_memset(&b[2], 16, '?');
+    ASSERT_MEMCMP(b, char, 'a', 'b',
+                  '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
+                  's', 't', 'u', 'v', 'w', 'x', 'y', 'z');
+}
+
+AGBTEST(memset, big_offset_3) {
+    char b[26];
+    fill_ascii_buffer(b, 26, 'a');
+
+    __aeabi_memset(&b[3], 16, '?');
+    ASSERT_MEMCMP(b, char, 'a', 'b', 'c',
+                  '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
+                  't', 'u', 'v', 'w', 'x', 'y', 'z');
+}
+
+void fill_ascii_buffer(void* buf, size_t len, char base) {
+    char* b = (char*) buf;
+    for (size_t i = 0; i < len; ++i) {
+        b[i] = (char) (base + (i % 26));
+    }
+}


### PR DESCRIPTION
Also fixes a memset bug (aligning by half word erases upper byte)

This test suite is built against my own internal toolchain that I will be publishing at some point in the future. It's probably worth making a Meson equivalent for sdk-seven in the mean time.

It's also very rough and early, just prints out tests that fails