### PR TITLE
Fix memset (again) for >64 bytes case

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@
 #===============================================================================
 
 project('agbabi', 'c',
-  version: '2.1.2',
+  version: '2.1.3',
   license: 'Zlib',
   meson_version: '>=0.56.2',
   default_options: [

--- a/source/context.s
+++ b/source/context.s
@@ -22,6 +22,7 @@
 
     .section .iwram.getcontext, "ax", %progbits
     .global getcontext
+    .type getcontext, %function
 getcontext:
     @ Save r0
     str     r0, [r0, #OFF_REG_R0]

--- a/source/coroutine.s
+++ b/source/coroutine.s
@@ -13,6 +13,7 @@
 
     .section .iwram.__agbabi_coro_resume, "ax", %progbits
     .global __agbabi_coro_resume
+    .type __agbabi_coro_resume, %function
 __agbabi_coro_resume:
     push    {r4-r11, lr}
     mov     r1, sp
@@ -26,6 +27,7 @@ __agbabi_coro_resume:
 
     .section .iwram.__agbabi_coro_yield, "ax", %progbits
     .global __agbabi_coro_yield
+    .type __agbabi_coro_yield, %function
 __agbabi_coro_yield:
     push    {r4-r11, lr}
     mov     r2, sp
@@ -40,6 +42,7 @@ __agbabi_coro_yield:
 
     .section .iwram.__agbabi_coro_pop, "ax", %progbits
     .global __agbabi_coro_pop
+    .type __agbabi_coro_pop, %function
 __agbabi_coro_pop:
     ldr     r1, [sp, #4]
 

--- a/source/fiq_memcpy.s
+++ b/source/fiq_memcpy.s
@@ -15,6 +15,7 @@
 
     .section .iwram.__agbabi_fiq_memcpy4, "ax", %progbits
     .global __agbabi_fiq_memcpy4
+    .type __agbabi_fiq_memcpy4, %function
 __agbabi_fiq_memcpy4:
     cmp     r2, #48
     blt     .Lcopy_words
@@ -61,6 +62,7 @@ __agbabi_fiq_memcpy4:
 
     .section .iwram.__agbabi_fiq_memcpy4x4, "ax", %progbits
     .global __agbabi_fiq_memcpy4x4
+    .type __agbabi_fiq_memcpy4x4, %function
 __agbabi_fiq_memcpy4x4:
     push    {r4-r10}
     cmp     r2, #48

--- a/source/idiv.s
+++ b/source/idiv.s
@@ -15,10 +15,12 @@
     @ after it, r0 has the quotient and r1 has the modulo
     .section .iwram.__aeabi_idivmod, "ax", %progbits
     .global __aeabi_idivmod
+    .type __aeabi_idivmod, %function
 __aeabi_idivmod:
     @ Fallthrough
 
     .global __aeabi_idiv
+    .type __aeabi_idiv, %function
 __aeabi_idiv:
     @ Test division by zero
     cmp     r1, #0

--- a/source/irq.s
+++ b/source/irq.s
@@ -19,6 +19,7 @@
 
     .section .iwram.__agbabi_irq_empty, "ax", %progbits
     .global __agbabi_irq_empty
+    .type __agbabi_irq_empty, %function
 __agbabi_irq_empty:
     mov     r0, #REG_BASE
 
@@ -38,6 +39,7 @@ __agbabi_irq_empty:
 
     .section .iwram.__agbabi_irq_user,"ax",%progbits
     .global __agbabi_irq_user
+    .type __agbabi_irq_user, %function
 __agbabi_irq_user:
     mov     r1, #REG_BASE
 

--- a/source/ldiv.s
+++ b/source/ldiv.s
@@ -17,10 +17,12 @@
     @ after it, r0:r1 has the quotient and r2:r3 has the modulo
     .section .iwram.__aeabi_ldivmod, "ax", %progbits
     .global __aeabi_ldivmod
+    .type __aeabi_ldivmod, %function
 __aeabi_ldivmod:
     @ Fallthrough
 
     .global __agbabi_ldiv
+    .type __agbabi_ldiv, %function
 __agbabi_ldiv:
     @ Test division by zero
     cmp     r3, #0

--- a/source/lmul.s
+++ b/source/lmul.s
@@ -13,6 +13,7 @@
 
     .section .iwram.__aeabi_lmul, "ax", %progbits
     .global __aeabi_lmul
+    .type __aeabi_lmul, %function
 __aeabi_lmul:
     mul     r3, r0, r3
     mla     r1, r2, r1, r3
@@ -22,6 +23,7 @@ __aeabi_lmul:
 
     .section .iwram.__aeabi_llsl, "ax", %progbits
     .global __aeabi_llsl
+    .type __aeabi_llsl, %function
 __aeabi_llsl:
     subs    r3, r2, #32
     rsb     r12, r2, #32
@@ -33,6 +35,7 @@ __aeabi_llsl:
 
     .section .iwram.__aeabi_llsr, "ax", %progbits
     .global __aeabi_llsr
+    .type __aeabi_llsr, %function
 __aeabi_llsr:
     subs    r3, r2, #32
     rsb     r12, r2, #32
@@ -44,6 +47,7 @@ __aeabi_llsr:
 
     .section .iwram.__aeabi_lasr, "ax", %progbits
     .global __aeabi_lasr
+    .type __aeabi_lasr, %function
 __aeabi_lasr:
     subs    r3, r2, #32
     rsb     r12, r2, #32

--- a/source/memcpy.s
+++ b/source/memcpy.s
@@ -19,6 +19,7 @@
 
     .section .iwram.__aeabi_memcpy, "ax", %progbits
     .global __aeabi_memcpy
+    .type __aeabi_memcpy, %function
 __aeabi_memcpy:
     @ >6-bytes is roughly the threshold when byte-by-byte copy is slower
     cmp     r2, #6
@@ -43,8 +44,10 @@ __aeabi_memcpy:
     @ r0, r1 are now word aligned
 
     .global __aeabi_memcpy8
+    .type __aeabi_memcpy8, %function
 __aeabi_memcpy8:
     .global __aeabi_memcpy4
+    .type __aeabi_memcpy4, %function
 __aeabi_memcpy4:
     cmp     r2, #32
     blt     .Lcopy_words
@@ -92,6 +95,7 @@ __aeabi_memcpy4:
     @ r0, r1 are now half aligned
 
     .global __agbabi_memcpy2
+    .type __agbabi_memcpy2, %function
 __agbabi_memcpy2:
     subs    r2, r2, #2
     ldrgeh  r3, [r1], #2
@@ -106,6 +110,7 @@ __agbabi_memcpy2:
     bx      lr
 
     .global __agbabi_memcpy1
+    .type __agbabi_memcpy1, %function
 __agbabi_memcpy1:
     subs    r2, r2, #1
     ldrgeb  r3, [r1], #1
@@ -115,6 +120,7 @@ __agbabi_memcpy1:
 
     .section .iwram.memcpy, "ax", %progbits
     .global memcpy
+    .type memcpy, %function
 memcpy:
     push    {r0, lr}
     bl      __aeabi_memcpy

--- a/source/memmove.s
+++ b/source/memmove.s
@@ -15,6 +15,7 @@
 
     .section .iwram.__aeabi_memmove, "ax", %progbits
     .global __aeabi_memmove
+    .type __aeabi_memmove, %function
 __aeabi_memmove:
     cmp     r0, r1
     .extern __agbabi_rmemcpy
@@ -23,8 +24,10 @@ __aeabi_memmove:
     b       __aeabi_memcpy
 
     .global __aeabi_memmove8
+    .type __aeabi_memmove8, %function
 __aeabi_memmove8:
     .global __aeabi_memmove4
+    .type __aeabi_memmove4, %function
 __aeabi_memmove4:
     cmp     r0, r1
     .extern __agbabi_rmemcpy
@@ -33,6 +36,7 @@ __aeabi_memmove4:
     b       __aeabi_memcpy4
 
     .global __agbabi_memmove1
+    .type __agbabi_memmove1, %function
 __agbabi_memmove1:
     cmp     r0, r1
     .extern __agbabi_rmemcpy1
@@ -42,6 +46,7 @@ __agbabi_memmove1:
 
     .section .iwram.memmove, "ax", %progbits
     .global memmove
+    .type memmove, %function
 memmove:
     push    {r0, lr}
     bl      __aeabi_memmove

--- a/source/memset.s
+++ b/source/memset.s
@@ -20,19 +20,23 @@
 
     .section .iwram.__aeabi_memclr, "ax", %progbits
     .global __aeabi_memclr
+    .type __aeabi_memclr, %function
 __aeabi_memclr:
     mov     r2, #0
     b       __aeabi_memset
 
     .global __aeabi_memclr8
+    .type __aeabi_memclr8, %function
 __aeabi_memclr8:
     .global __aeabi_memclr4
+    .type __aeabi_memclr4, %function
 __aeabi_memclr4:
     mov     r2, #0
     b       __agbabi_wordset4
 
     .section .iwram.__aeabi_memset, "ax", %progbits
     .global __aeabi_memset
+    .type __aeabi_memset, %function
 __aeabi_memset:
     @ < 8 bytes probably won't be aligned: go byte-by-byte
     cmp     r1, #8
@@ -48,18 +52,22 @@ __aeabi_memset:
     subcs   r1, r1, #2
 
     .global __aeabi_memset8
+    .type __aeabi_memset8, %function
 __aeabi_memset8:
     .global __aeabi_memset4
+    .type __aeabi_memset4, %function
 __aeabi_memset4:
     lsl     r2, r2, #24
     orr     r2, r2, r2, lsr #8
     orr     r2, r2, r2, lsr #16
 
     .global __agbabi_wordset4
+    .type __agbabi_wordset4, %function
 __agbabi_wordset4:
     mov     r3, r2
 
     .global __agbabi_lwordset4
+    .type __agbabi_lwordset4, %function
 __agbabi_lwordset4:
     @ 16 words is roughly the threshold when lwordset is slower
     cmp     r1, #64
@@ -101,6 +109,7 @@ __agbabi_lwordset4:
     bx      lr
 
     .global __agbabi_memset1
+    .type __agbabi_memset1, %function
 __agbabi_memset1:
     subs    r1, r1, #1
     strgeb  r2, [r0], #1
@@ -109,6 +118,7 @@ __agbabi_memset1:
 
     .section .iwram.memset, "ax", %progbits
     .global memset
+    .type memset, %function
 memset:
     mov     r3, r1
     mov     r1, r2

--- a/source/memset.s
+++ b/source/memset.s
@@ -75,8 +75,8 @@ __agbabi_lwordset4:
     mov     r9, r3
 
 .Lset_8_words:
-    stmgeia r0!, {r2-r9}
     subs    r1, r1, #32
+    stmgeia r0!, {r2-r9}
     bgt     .Lset_8_words
     pop     {r4-r9}
     bxeq    lr

--- a/source/memset.s
+++ b/source/memset.s
@@ -97,9 +97,7 @@ __agbabi_lwordset4:
     @ Set tail
     joaobapt_test r1
     strcsh  r2, [r0], #2
-    subcs   r1, r1, #2
     strmib  r2, [r0], #1
-    submi   r1, r1, #1
     bx      lr
 
     .global __agbabi_memset1

--- a/source/rmemcpy.s
+++ b/source/rmemcpy.s
@@ -15,6 +15,7 @@
 
     .section .iwram.__agbabi_rmemcpy, "ax", %progbits
     .global __agbabi_rmemcpy
+    .type __agbabi_rmemcpy, %function
 __agbabi_rmemcpy:
     @ >6-bytes is roughly the threshold when byte-by-byte copy is slower
     cmp     r2, #6
@@ -96,6 +97,7 @@ __agbabi_rmemcpy:
     bx      lr
 
     .global __agbabi_rmemcpy1
+    .type __agbabi_rmemcpy1, %function
 __agbabi_rmemcpy1:
     subs    r2, r2, #1
     ldrgeb  r3, [r1, r2]

--- a/source/sine.s
+++ b/source/sine.s
@@ -13,6 +13,7 @@
 
     .section .iwram.__agbabi_sin, "ax", %progbits
     .global __agbabi_sin
+    .type __agbabi_sin, %function
 __agbabi_sin:
     mov     r0, r0, lsl #17
     teq     r0, r0, lsl #1

--- a/source/sqrt.s
+++ b/source/sqrt.s
@@ -13,6 +13,7 @@
 
     .section .iwram.__agbabi_sqrt, "ax", %progbits
     .global __agbabi_sqrt
+    .type __agbabi_sqrt, %function
 __agbabi_sqrt:
     mov     r1, #3 << 30
     mov     r2, #1 << 30

--- a/source/uidiv.s
+++ b/source/uidiv.s
@@ -15,10 +15,12 @@
 
     .section .iwram.__aeabi_uidivmod, "ax", %progbits
     .global __aeabi_uidivmod
+    .type __aeabi_uidivmod, %function
 __aeabi_uidivmod:
     @ Fallthrough
 
     .global __aeabi_uidiv
+    .type __aeabi_uidiv, %function
 __aeabi_uidiv:
 
     @ Check for division by zero
@@ -28,6 +30,7 @@ __aeabi_uidiv:
     @ Fallthrough
 
     .global __agbabi_unsafe_uidivmod
+    .type __agbabi_unsafe_uidivmod, %function
 __agbabi_unsafe_uidivmod:
     @ If n < d, just bail out as well
     cmp     r0, r1    @ n, d

--- a/source/uldiv.s
+++ b/source/uldiv.s
@@ -21,10 +21,12 @@
     .align 2
     .arm
     .global __aeabi_uldivmod
+    .type __aeabi_uldivmod, %function
 __aeabi_uldivmod:
     @ Fallthrough
 
     .global __agbabi_uldiv
+    .type __agbabi_uldiv, %function
 __agbabi_uldiv:
     @ Check if the high word of the denominator is zero
     cmp     r3, #0
@@ -33,6 +35,7 @@ __agbabi_uldiv:
     @ Fallthrough
 
     .global __agbabi_unsafe_uldivmod
+    .type __agbabi_unsafe_uldivmod, %function
 __agbabi_unsafe_uldivmod:
     @ Check if the denominator is greater than the numerator and exit early if so
     cmp     r1, r3

--- a/source/uluidiv.s
+++ b/source/uluidiv.s
@@ -17,10 +17,12 @@
     @ after it, r0:r1 has the quotient and r2 has the modulo. r3 = 0 to be compatible with uldivmod
     .section .iwram.__agbabi_uluidivmod, "ax", %progbits
     .global __agbabi_uluidivmod
+    .type __agbabi_uluidivmod, %function
 __agbabi_uluidivmod:
     @ Fallthrough
 
     .global __agbabi_uluidiv
+    .type __agbabi_uluidiv, %function
 __agbabi_uluidiv:
 
     @ Check for division by zero
@@ -30,6 +32,7 @@ __agbabi_uluidiv:
     @ Fallthrough
 
     .global __agbabi_unsafe_uluidivmod
+    .type __agbabi_unsafe_uluidivmod, %function
 __agbabi_unsafe_uluidivmod:
     @ If the second word is 0, just do normal 32x32 division
     cmp     r1, #0

--- a/test/test_memset.c
+++ b/test/test_memset.c
@@ -82,6 +82,17 @@ AGBTEST(memset, big_offset_3) {
                   't', 'u', 'v', 'w', 'x', 'y', 'z');
 }
 
+AGBTEST(memset, very_big_offset_1) {
+    char b[130];
+    fill_ascii_buffer(b, 130, 'a');
+
+    __aeabi_memset(&b[1], 128, '?');
+    ASSERT_EQUAL(b[0], 'a');
+    ASSERT_EQUAL(b[1], '?');
+    ASSERT_EQUAL(b[128], '?');
+    ASSERT_EQUAL(b[129], 'z');
+}
+
 void fill_ascii_buffer(void* buf, size_t len, char base) {
     char* b = (char*) buf;
     for (size_t i = 0; i < len; ++i) {


### PR DESCRIPTION
Also removed a needless `r1` update (probably from a copy-paste), and added `.type` decorator to assembly functions

Thanks to @asiekierka for writing the failing test case