### PR TITLE
Mode 4 pixel buffer column pack/unpack utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(agbabi STATIC
     source/irq.s
     source/ldiv.s
     source/lmul.s
+    source/m4column.s
     source/memcpy.s
     source/memmove.s
     source/memset.s

--- a/docs/agbabi.md
+++ b/docs/agbabi.md
@@ -273,3 +273,28 @@ int main() {
 | Signature                   | Description                                |
 |:----------------------------|:-------------------------------------------|
 | `int __agbabi_poll_ewram()` | Returns 1 for fast EWRAM, 0 for slow EWRAM |
+
+## Mode 4 Column Unpack/Pack
+
+Pixel buffer column pack/unpack utilities for Mode 4 video memory (240 pixels wide, 8 bits per pixel).
+
+### 4x Columns
+
+Packs/unpacks 4 columns of pixel data at a time.
+
+```c
+#include <agbabi.h>
+
+#define VIDEO4_VRAM (*(char*) 0x6000000)
+
+int main() {
+    char columnBuffer[160][4];
+    __agbabi_m4col_unpack4(columnBuffer, VIDEO4_VRAM + 4, 160); /* Read 4x160 pixels into columnBuffer, starting at column 4 */
+    __agbabi_m4col_pack4(VIDEO4_VRAM + 8, columnBuffer, 160); /* Write 4x160 pixels from columnBuffer, starting at column 8 */
+}
+```
+
+| Signature                                                            | Description                                                                                            |
+|:---------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
+| `void __agbabi_m4col_pack4(void* dest, const void* src, size_t n)`   | Packs n rows of 4 columns of pixels from src into dest<br/>Assumes n is non-zero and a multiple of 4   |
+| `void __agbabi_m4col_unpack4(void* dest, const void* src, size_t n)` | Unpacks n rows of 4 columns of pixels from src into dest<br/>Assumes n is non-zero and a multiple of 4 |

--- a/docs/agbabi.md
+++ b/docs/agbabi.md
@@ -298,3 +298,24 @@ int main() {
 |:---------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
 | `void __agbabi_m4col_pack4(void* dest, const void* src, size_t n)`   | Packs n rows of 4 columns of pixels from src into dest<br/>Assumes n is non-zero and a multiple of 4   |
 | `void __agbabi_m4col_unpack4(void* dest, const void* src, size_t n)` | Unpacks n rows of 4 columns of pixels from src into dest<br/>Assumes n is non-zero and a multiple of 4 |
+
+### 2x Columns
+
+Packs/unpacks 2 columns of pixel data at a time.
+
+```c
+#include <agbabi.h>
+
+#define VIDEO4_VRAM (*(char*) 0x6000000)
+
+int main() {
+    char columnBuffer[160][2];
+    __agbabi_m4col_unpack2(columnBuffer, VIDEO4_VRAM + 2, 160); /* Read 2x160 pixels into columnBuffer, starting at column 2 */
+    __agbabi_m4col_pack2(VIDEO4_VRAM + 4, columnBuffer, 160); /* Write 2x160 pixels from columnBuffer, starting at column 4 */
+}
+```
+
+| Signature                                                            | Description                                                                                            |
+|:---------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
+| `void __agbabi_m4col_pack2(void* dest, const void* src, size_t n)`   | Packs n rows of 2 columns of pixels from src into dest<br/>Assumes n is non-zero and a multiple of 4   |
+| `void __agbabi_m4col_unpack2(void* dest, const void* src, size_t n)` | Unpacks n rows of 2 columns of pixels from src into dest<br/>Assumes n is non-zero and a multiple of 4 |

--- a/include/agbabi.h
+++ b/include/agbabi.h
@@ -307,6 +307,22 @@ void __agbabi_m4col_pack4(void* __restrict__ dest, const void* __restrict__ src,
  */
 void __agbabi_m4col_unpack4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
 
+/**
+ * Packs exactly 320 bytes from src into dest
+ * @param dest Pointer to the first byte of a column on a mode 4 frame-buffer (240x160 resolution frame-buffer)
+ * @param src Pointer to two linear arrays of 160 bytes (160x2 pixel data)
+ * @param n Number of rows to pack (Must be non-zero, and multiple of 4)
+ */
+void __agbabi_m4col_pack2(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Unpacks exactly 320 bytes from src into dest
+ * @param dest Pointer to two linear arrays of 160 bytes (160x2 pixel data)
+ * @param src Pointer to the first byte of a column on a mode 4 frame-buffer (240x160 resolution frame-buffer)
+ * @param n Number of rows to unpack (Must be non-zero, and multiple of 4)
+ */
+void __agbabi_m4col_unpack2(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/agbabi.h
+++ b/include/agbabi.h
@@ -291,6 +291,22 @@ int __agbabi_multiboot(const __agbabi_multiboot_t* param) __attribute__((nonnull
  */
 int __agbabi_poll_ewram(void) __attribute__((const));
 
+/**
+ * Packs exactly 640 bytes from src into dest
+ * @param dest Pointer to the first byte of a column on a mode 4 frame-buffer (240x160 resolution frame-buffer)
+ * @param src Pointer to four linear arrays of 160 bytes (160x4 pixel data)
+ * @param n Number of rows to pack (Must be non-zero, and multiple of 4)
+ */
+void __agbabi_m4col_pack4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Unpacks exactly 640 bytes from src into dest
+ * @param dest Pointer to four linear arrays of 160 bytes (160x4 pixel data)
+ * @param src Pointer to the first byte of a column on a mode 4 frame-buffer (240x160 resolution frame-buffer)
+ * @param n Number of rows to unpack (Must be non-zero, and multiple of 4)
+ */
+void __agbabi_m4col_unpack4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/m4column.s
+++ b/source/m4column.s
@@ -1,0 +1,140 @@
+@===============================================================================
+@
+@ Support:
+@    __agbabi_m4col_pack4, __agbabi_m4col_unpack4
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+.syntax unified
+
+    .arm
+    .align 2
+
+    .section .iwram.__agbabi_m4col_pack4, "ax", %progbits
+    .global __agbabi_m4col_pack4
+    .type __agbabi_m4col_pack4, %function
+__agbabi_m4col_pack4:
+    @ r0 = vram, r1 = source, r2 = number of rows (multiple of 4, non-zero)
+    push    {r4-r7}
+
+.Lpack_4_rows:
+    @ read 4 pixels of column 0, 1, 2, 3
+    ldr     r7, [r1, #480]
+    ldr     r6, [r1, #320]
+    ldr     r5, [r1, #160]
+    ldr     r4, [r1], #4
+    @ r4-r7 = {33221100, 77665544, bbaa9988, ffeeddcc}
+
+    @ row 0
+    and     r3, r4, #0xff           @ r3 = {______00}
+    and     r12, r5, #0xff
+    orr     r3, r3, r12, lsl #8     @ r3 = {____4400}
+    and     r12, r6, #0xff
+    orr     r3, r3, r12, lsl #16    @ r3 = {__884400}
+    orr     r3, r3, r7, lsl #24     @ r3 = {cc884400}
+    @ r3 = {cc884400}
+    str     r3, [r0], #240
+
+    @ row 1
+    and     r3, r5, #0xff00         @ r3 = {____55__}
+    and     r12, r4, #0xff00
+    orr     r3, r3, r12, lsr #8     @ r3 = {____5511}
+    and     r12, r6, #0xff00
+    orr     r3, r3, r12, lsl #8     @ r3 = {__995511}
+    and     r12, r7, #0xff00
+    orr     r3, r3, r12, lsl #16    @ r3 = {dd995511}
+    @ r3 = {dd995511}
+    str     r3, [r0], #240
+
+    @ row 2
+    and     r3, r6, #0xff0000       @ r3 = {__aa____}
+    and     r12, r4, #0xff0000
+    orr     r3, r3, r12, lsr #16    @ r3 = {__aa__22}
+    and     r12, r5, #0xff0000
+    orr     r3, r3, r12, lsr #8     @ r3 = {__aaa6622}
+    and     r12, r7, #0xff0000
+    orr     r3, r3, r12, lsl #8     @ r3 = {eeaa6622}
+    @ r3 = {eeaa6622}
+    str     r3, [r0], #240
+
+    @ row 3
+    and     r3, r7, #0xff000000     @ r3 = {ff______}
+    orr     r3, r3, r4, lsr #24     @ r3 = {ff____33}
+    and     r12, r5, #0xff000000
+    orr     r3, r3, r12, lsr #16    @ r3 = {ff__7733}
+    and     r12, r6, #0xff000000
+    orr     r3, r3, r12, lsr #8     @ r3 = {ffbb7733}
+    @ r3 = {ffbb7733}
+    str     r3, [r0], #240
+
+    subs    r2, #4
+    bgt     .Lpack_4_rows
+
+    pop     {r4-r7}
+    bx      lr
+
+    .section .iwram.__agbabi_m4col_unpack4, "ax", %progbits
+    .global __agbabi_m4col_unpack4
+    .type __agbabi_m4col_unpack4, %function
+__agbabi_m4col_unpack4:
+    @ r0 = destination, r1 = vram, r2 = number of rows (multiple of 4, non-zero)
+    push    {r4-r7}
+
+.Lunpack_4_rows:
+    @ read 4 pixels of column 0, 1, 2, 3
+    ldr     r4, [r1], #240
+    ldr     r5, [r1], #240
+    ldr     r6, [r1], #240
+    ldr     r7, [r1], #240
+    @ r4-r7 = {cc884400, dd995511, eeaa6622, ffbb7733}
+
+    @ column 3
+    and     r3, r7, #0xff000000     @ r3 = {ff______}
+    and     r12, r6, #0xff000000
+    orr     r3, r3, r12, lsr #8     @ r3 = {ffee____}
+    and     r12, r5, #0xff000000
+    orr     r3, r3, r12, lsr #16    @ r3 = {ffeedd__}
+    orr     r3, r3, r4, lsr #24     @ r3 = {ffeeddcc}
+    @ r3 = {ffeeddcc}
+    str     r3, [r0, #480]
+
+    @ column 2
+    and     r3, r6, #0xff0000       @ r3 = {__aa____}
+    and     r12, r7, #0xff0000
+    orr     r3, r3, r12, lsl #8     @ r3 = {bbaa____}
+    and     r12, r5, #0xff0000
+    orr     r3, r3, r12, lsr #8     @ r3 = {bbaa99__}
+    and     r12, r4, #0xff0000
+    orr     r3, r3, r12, lsr #16    @ r3 = {bbaa9988}
+    @ r3 = {bbaa9988}
+    str     r3, [r0, #320]
+
+    @ column 1
+    and     r3, r5, #0xff00         @ r3 = {____55__}
+    and     r12, r7, #0xff00
+    orr     r3, r3, r12, lsl #16    @ r3 = {77__55__}
+    and     r12, r6, #0xff00
+    orr     r3, r3, r12, lsl #8     @ r3 = {776655__}
+    and     r12, r4, #0xff00
+    orr     r3, r3, r12, lsr #8     @ r3 = {77665544}
+    @ r3 = {77665544}
+    str     r3, [r0, #160]
+
+    @ column 0
+    and     r3, r4, #0xff           @ r3 = {______00}
+    orr     r3, r3, r7, lsl #24     @ r3 = {33____00}
+    and     r12, r6, #0xff
+    orr     r3, r3, r12, lsl #16    @ r3 = {3322__00}
+    and     r12, r5, #0xff
+    orr     r3, r3, r12, lsl #8     @ r3 = {33221100}
+    @ r3 = {33221100}
+    str     r3, [r0], #4
+
+    subs    r2, #4
+    bgt     .Lunpack_4_rows
+
+    pop     {r4-r7}
+    bx      lr


### PR DESCRIPTION
These are intended for column-based software renderers (typically ray-casters and Doom-like engines).

## Background

Because video memory can only be written in 2-bytes there is a common pattern of "read 2-bytes, modify 1-byte, write 2-bytes" for writing a single pixel in Mode 4.

One trick around this is to buffer two pixels for rendering, before transferring to video memory. Often it is faster to buffer even more pixels to allow the compiler to optimise pixel writes into the buffer, and to utilise high-speed memory transfers of the renderer pixels (either with DMA or a fast copy routine such as `__agbabi_fiq_memcpy4x4`).

This trick only applies for software renderers that rasterise graphics scanline-by-scanline. For software renderers such as ray-casters and Doom-like engines the scene is rasterised vertically, column-by-column.

In addition to this: Compilers have a much easier time optimising for linear arrays of data, so it is usually beneficial to operate on pixel data linearly.

## Column pack/unpack

This PR introduces utilities provide `unpack` for reading multiple columns of pixels from a Mode 4 buffer (assumed 240 pixels wide), and `pack` for writing multiple columns of pixels from linear buffers.

```c
char pixelBuffer[160][4];

__agbabi_m4col_unpack4(pixelBuffer, (const void*) 0x6000000, 160); // Unpack 4x160 pixels into pixelBuffer

// Modify pixelBuffer here

__agbabi_m4col_pack4((void*) 0x6000000, pixelBuffer, 160); // Pack pixelBuffer into 4 columns of 160 pixels
```

## Open question

Video memory can be read as single-bytes. Could `unpack` be faster with a simple `ldrb`/`strb` loop? It's the same number of instructions, and also avoids the stack `push`/`pop`, but are there performance concerns regarding having 16 calls to both `ldrb` and `strb`?