### PR TITLE
memcpy, memmove, memset, rmemcpy: more granular sections

### DIFF
--- a/source/memcpy.s
+++ b/source/memcpy.s
@@ -110,6 +110,7 @@ __agbabi_memcpy2:
     strbne  r3, [r0]
     bx      lr
 
+    .section .iwram.__agbabi_memcpy1, "ax", %progbits
     .global __agbabi_memcpy1
     .type __agbabi_memcpy1, %function
 __agbabi_memcpy1:

--- a/source/memmove.s
+++ b/source/memmove.s
@@ -25,6 +25,7 @@ __aeabi_memmove:
     .extern __aeabi_memcpy
     b       __aeabi_memcpy
 
+    .section .iwram.__aeabi_memmove8, "ax", %progbits
     .global __aeabi_memmove8
     .type __aeabi_memmove8, %function
 __aeabi_memmove8:
@@ -37,6 +38,7 @@ __aeabi_memmove4:
     .extern __aeabi_memcpy4
     b       __aeabi_memcpy4
 
+    .section .iwram.__agbabi_memmove1, "ax", %progbits
     .global __agbabi_memmove1
     .type __agbabi_memmove1, %function
 __agbabi_memmove1:

--- a/source/memset.s
+++ b/source/memset.s
@@ -109,6 +109,7 @@ __agbabi_lwordset4:
     strbmi  r2, [r0], #1
     bx      lr
 
+    .section .iwram.__agbabi_memset1, "ax", %progbits
     .global __agbabi_memset1
     .type __agbabi_memset1, %function
 __agbabi_memset1:

--- a/source/rmemcpy.s
+++ b/source/rmemcpy.s
@@ -97,6 +97,7 @@ __agbabi_rmemcpy:
     strb    r3, [r0]
     bx      lr
 
+    .section .iwram.__agbabi_rmemcpy1, "ax", %progbits
     .global __agbabi_rmemcpy1
     .type __agbabi_rmemcpy1, %function
 __agbabi_rmemcpy1:


### PR DESCRIPTION
When auditing a regression in BlocksDS, I noticed that some additional ASM functions could live in their own sections, as they have no "fallthrough" dependency on the preceding function. As they exist in IWRAM, every few bytes saved matter.