### PR TITLE
rtc: Fix newlib-specific reentrancy include.

### DIFF
--- a/source/rtc.c
+++ b/source/rtc.c
@@ -15,7 +15,10 @@
 */
 
 #include <agbabi.h>
-#include <reent.h>
+// sys/types.h pulls in sys/config.h on newlib, which defines __DYNAMIC_REENT__.
+// This approach preserves compatibility with other future POSIX-compliant libc
+// implementations.
+#include <sys/types.h>
 #include <sys/time.h>
 
 #define RTC_OK      (0x00)


### PR DESCRIPTION
`<reent.h>` is not guaranteed to exist on all libc implementations; in particular, picolibc strips out the whole system and replaces it with usage of compiler TLS, which is itself opt-in.

This fixes building agbabi with picolibc (and potentially other POSIX-compliant libc implementations in the future). Please verify that the reentrant symbol still gets built on reentrant newlib-based platforms.